### PR TITLE
Check if it has args

### DIFF
--- a/lua/podium.lua
+++ b/lua/podium.lua
@@ -1446,7 +1446,7 @@ package.preload["podium"] = function()
 end
 
 
-if arg[0]:match('podium') then
+if #arg > 0 and arg[0]:match('podium') then
   local input
   if arg[2] then
     local ifile = io.open(arg[2], "r")


### PR DESCRIPTION
When it is required as a library, `args` is empty.
So it is neccessary to be checked if it has values.